### PR TITLE
Feat/transaction timeout wrapwithtoast

### DIFF
--- a/web/src/utils/wrapWithToast.ts
+++ b/web/src/utils/wrapWithToast.ts
@@ -25,24 +25,6 @@ export const infoToast = (message: string) => toast.info(message, OPTIONS);
 export const successToast = (message: string) => toast.success(message, OPTIONS);
 export const errorToast = (message: string) => toast.error(message, OPTIONS);
 
-/**
- * Wraps a contract write operation with toast notifications and timeout handling.
- *
- * This function provides a robust way to handle blockchain transactions with:
- * - User feedback through toast notifications
- * - Automatic timeout handling for transaction confirmations (5 minutes default)
- * - Comprehensive error handling for various failure scenarios
- *
- * Timeout Mechanism:
- * - Uses Promise.race to compete between transaction confirmation and timeout
- * - Default timeout is 5 minutes (300,000 ms) configurable via TX_RECEIPT_TIMEOUT_MS
- * - If timeout occurs, shows user-friendly message about checking blockchain explorer
- * - Timeout doesn't affect the actual transaction - it may still confirm later
- *
- * @param contractWrite - Function that returns a promise resolving to transaction hash
- * @param publicClient - Viem PublicClient for blockchain interaction
- * @returns Promise resolving to transaction status and receipt (if available)
- */
 export async function wrapWithToast(
   contractWrite: () => Promise<`0x${string}`>,
   publicClient: PublicClient
@@ -51,29 +33,28 @@ export async function wrapWithToast(
   try {
     const hash = await contractWrite();
 
-    // Timeout promise for transaction confirmation
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Transaction confirmation timed out after 5 minutes.")), TX_RECEIPT_TIMEOUT_MS)
-    );
-
-    const res: TransactionReceipt = await Promise.race([
-      publicClient.waitForTransactionReceipt({ hash, confirmations: 2 }),
-      timeoutPromise,
-    ]);
+    // Use viem's built-in timeout option.
+    const res: TransactionReceipt = await publicClient.waitForTransactionReceipt({
+      hash,
+      confirmations: 2,
+      timeout: TX_RECEIPT_TIMEOUT_MS,
+    });
 
     const status = res.status === "success";
-
     if (status) successToast("Transaction mined!");
     else errorToast("Transaction reverted!");
 
     return { status, result: res };
   } catch (error: any) {
-    if (error instanceof Error && error.message.includes("timed out")) {
+    // If Viem exposes a dedicated TimeoutError, prefer that.
+    // Otherwise, check error message as fallback.
+    if (error?.name === "TimeoutError" || error?.message?.toLowerCase().includes("timed out")) {
       errorToast(
         "Transaction is taking longer than expected. It may still confirm. Please check the transaction status on the blockchain explorer."
       );
     } else {
-      errorToast(parseWagmiError(error));
+      const msg = parseWagmiError(error) || "Something went wrong. Please try again.";
+      errorToast(msg);
     }
     return { status: false };
   }

--- a/web/src/utils/wrapWithToast.ts
+++ b/web/src/utils/wrapWithToast.ts
@@ -1,7 +1,9 @@
 import { toast, ToastPosition, Theme } from "react-toastify";
 import { PublicClient, TransactionReceipt } from "viem";
-
 import { parseWagmiError } from "./parseWagmiError";
+
+// Timeout for transaction confirmation (5 minutes)
+const TX_RECEIPT_TIMEOUT_MS = 5 * 60 * 1000;
 
 export const OPTIONS = {
   position: "top-center" as ToastPosition,
@@ -23,29 +25,60 @@ export const infoToast = (message: string) => toast.info(message, OPTIONS);
 export const successToast = (message: string) => toast.success(message, OPTIONS);
 export const errorToast = (message: string) => toast.error(message, OPTIONS);
 
+/**
+ * Wraps a contract write operation with toast notifications and timeout handling.
+ *
+ * This function provides a robust way to handle blockchain transactions with:
+ * - User feedback through toast notifications
+ * - Automatic timeout handling for transaction confirmations (5 minutes default)
+ * - Comprehensive error handling for various failure scenarios
+ *
+ * Timeout Mechanism:
+ * - Uses Promise.race to compete between transaction confirmation and timeout
+ * - Default timeout is 5 minutes (300,000 ms) configurable via TX_RECEIPT_TIMEOUT_MS
+ * - If timeout occurs, shows user-friendly message about checking blockchain explorer
+ * - Timeout doesn't affect the actual transaction - it may still confirm later
+ *
+ * @param contractWrite - Function that returns a promise resolving to transaction hash
+ * @param publicClient - Viem PublicClient for blockchain interaction
+ * @returns Promise resolving to transaction status and receipt (if available)
+ */
 export async function wrapWithToast(
   contractWrite: () => Promise<`0x${string}`>,
   publicClient: PublicClient
 ): Promise<WrapWithToastReturnType> {
-  toast.info("Transaction initiated", OPTIONS);
-  return await contractWrite()
-    .then(
-      async (hash) =>
-        await publicClient.waitForTransactionReceipt({ hash, confirmations: 2 }).then((res: TransactionReceipt) => {
-          const status = res.status === "success";
+  infoToast("Transaction initiated");
+  try {
+    const hash = await contractWrite();
 
-          if (status) toast.success("Transaction mined!", OPTIONS);
-          else toast.error("Transaction reverted!", OPTIONS);
+    // Timeout promise for transaction confirmation
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Transaction confirmation timed out after 5 minutes.")), TX_RECEIPT_TIMEOUT_MS)
+    );
 
-          return { status, result: res };
-        })
-    )
-    .catch((error) => {
-      toast.error(parseWagmiError(error), OPTIONS);
-      return { status: false };
-    });
+    const res: TransactionReceipt = await Promise.race([
+      publicClient.waitForTransactionReceipt({ hash, confirmations: 2 }),
+      timeoutPromise,
+    ]);
+
+    const status = res.status === "success";
+
+    if (status) successToast("Transaction mined!");
+    else errorToast("Transaction reverted!");
+
+    return { status, result: res };
+  } catch (error: any) {
+    if (error instanceof Error && error.message.includes("timed out")) {
+      errorToast(
+        "Transaction is taking longer than expected. It may still confirm. Please check the transaction status on the blockchain explorer."
+      );
+    } else {
+      errorToast(parseWagmiError(error));
+    }
+    return { status: false };
+  }
 }
 
 export async function catchShortMessage(promise: Promise<unknown>) {
-  return await promise.catch((error) => toast.error(parseWagmiError(error), OPTIONS));
+  return await promise.catch((error) => errorToast(parseWagmiError(error)));
 }


### PR DESCRIPTION
> Reopened from #15  with `master` as target (as requested by @tractorss).

---
# Add Transaction Confirmation Timeout to wrapWithToast
## What does this PR do?
Enhances the `wrapWithToast` utility to include a timeout for transaction confirmations. If a transaction is not confirmed within 5 minutes, the user is notified with a toast suggesting they check the blockchain explorer for status.

## Why is this change needed?
Previously, users could be left waiting indefinitely if a transaction was delayed or stuck, with no indication of what was happening. This change improves user experience by providing a clear, time-bounded feedback loop and guidance in case of slow or pending transactions.

## How does it work?
1. **Implements a 5-minute timeout** using `Promise.race` between `waitForTransactionReceipt` and a timeout promise.
2. **Shows a user-friendly toast** if the timeout is reached:  
   “Transaction is taking longer than expected. It may still confirm. Please check the transaction status on the blockchain explorer.”
3. **Maintains all existing toast flows** (success, revert, error) and does not change the function interface.
4. **All errors** (including timeout) are handled gracefully and surfaced to the user.

## What stays the same?
- All existing toast notifications for success, revert, and error
- The function’s signature and usage throughout the codebase
- Underlying transaction receipt logic, except for the added timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction receipts now display detailed success confirmations and error notifications
  * Transactions exceeding timeout now show helpful guidance to verify status on blockchain explorers

* **Bug Fixes**
  * Enhanced error handling with more informative messages for failed transactions
  * Improved user feedback consistency during transaction processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->